### PR TITLE
Ververs dagverbruik op dashboard automatisch

### DIFF
--- a/dsmr_frontend/templates/dsmr_frontend/dashboard.html
+++ b/dsmr_frontend/templates/dsmr_frontend/dashboard.html
@@ -146,66 +146,11 @@
     </div>
     {% endif %}
 
-    {% if consumption %}
+    {% if capabilities.electricity or capabilities.electricity_returned or capabilities.gas %}
     <div class="row consumption-block">
-        <div class="col-md-12">
-            <div class="panel">
-                <header class="panel-heading">
-                    {{ consumption.day }}
-                    
-                    <small class="pull-right">
-                        <a href="{% url 'admin:dsmr_stats_note_add' %}?day={% now 'DJANGO_DATE_FORMAT' %}">
-                            <span class="badge bg-green"><i class="fa fa-plus"></i> &nbsp; {% trans "Add note for today" %}</span>
-                        </a>
-                    </small>
-                </header>
-                <div class="panel-body">
-                    <table class="table table-condensed">
-                        <tr>
-                            <th class="col-md-6"></th>
-                            <th class="col-md-2">{% if capabilities.electricity %}{% trans "Consumed" %} ({% trans "kWh" noop %}{% if capabilities.gas %} / {% trans "m<sup>3</sup>" noop %}{% endif %}){% endif %}</th>
-                            <th class="col-md-2">{% if capabilities.electricity_returned %}{% trans "Returned" %} ({% trans "kWh" noop %}){% endif %}</th>
-                            <th class="col-md-2">{% trans "Cost" %} (&euro;)</th>
-                        </tr>
-                        {% if frontend_settings.merge_electricity_tariffs %}
-                        <tr>
-                            <td>{% if capabilities.electricity %}{% trans "Electricity (single tariff)" %}{% endif %}</td>
-                            <td><span class="badge bg-red">{% if capabilities.electricity %}{{ consumption.electricity_merged|default:'-'|floatformat:2 }} </span>{% endif %}</td>
-                            <td><span class="badge bg-green">{% if capabilities.electricity_returned %}{{ consumption.electricity_returned_merged|default:'-'|floatformat:2 }}{% endif %}</span></td>
-                            <td><span class="badge bg-black">{% if capabilities.electricity %}{{ consumption.electricity_cost_merged|default:'-' }}{% endif %}</span></td>
-                        </tr>
-                        {% else %}
-                        <tr>
-                            <td>{% if capabilities.electricity %}{% trans "Electricity 1 (low tariff)" %}{% endif %}</td>
-                            <td><span class="badge bg-red">{% if capabilities.electricity %}{{ consumption.electricity1|default:'-'|floatformat:2 }} </span>{% endif %}</td>
-                            <td><span class="badge bg-green">{% if capabilities.electricity_returned %}{{ consumption.electricity1_returned|default:'-'|floatformat:2 }}{% endif %}</span></td>
-                            <td><span class="badge bg-black">{% if capabilities.electricity %}{{ consumption.electricity1_cost|default:'-' }}{% endif %}</span></td>
-                        </tr>
-                        <tr>
-                            <td>{% if capabilities.electricity %}{% trans "Electricity 2 (high tariff)" %}{% endif %}</td>
-                            <td><span class="badge bg-red">{% if capabilities.electricity %}{{ consumption.electricity2|default:'-'|floatformat:2 }}{% endif %}</span></td>
-                            <td><span class="badge bg-green">{% if capabilities.electricity_returned %}{{ consumption.electricity2_returned|default:'-'|floatformat:2 }}{% endif %}</span></td>
-                            <td><span class="badge bg-black">{% if capabilities.electricity %}{{ consumption.electricity2_cost|default:'-' }}{% endif %}</span></td>
-                        </tr>
-                        {% endif %}
-                        
-                        {% if capabilities.gas %}
-                        <tr>
-                            <td> {% trans "Gas" %}</td>
-                            <td><span class="badge bg-orange">{{ consumption.gas|default:'-'|floatformat:2 }}</span></td>
-                            <td>&nbsp;</td>
-                            <td><span class="badge bg-black">{{ consumption.gas_cost|default:'-' }}</span></td>
-                        </tr>
-                        {% endif %}
-                        <tr>
-                            <td style="font-weight: bold;">{% trans "Total" %}</td>
-                            <td><span class="badge bg-red">{% if capabilities.electricity %}{{ consumption.electricity_merged|default:'-'|floatformat:2 }}  </span>{% endif %}</td>
-                            <td><span class="badge bg-green">{% if capabilities.electricity_returned %}{{ consumption.electricity_returned_merged|default:'-'|floatformat:2 }}{% endif %}</span></td>
-                            <td><span class="badge bg-black">{{ consumption.total_cost|default:'-' }}</span></td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
+        <div class="col-md-12" id="consumption_holder">
+            <div id="consumption-loader" class="xhr-hidden text-center"><i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i></div>
+            <div id="consumption-holder"></div>
         </div>
     </div>
     {% endif %}
@@ -407,8 +352,10 @@
                 /* Auto refresh. */
                 update_header();
                 setInterval(function(){ update_header(); }, 2500);
+                setInterval(function(){ update_consumption(); }, 20000)
                 setInterval(function(){ update_graphs(); }, 5000);
-                
+
+                initialize_consumption();
                 initialize_graphs();
             });
             
@@ -430,6 +377,23 @@
                     {
 	                    $("#latest_electricity_cost").html("&euro; " + response.latest_electricity_cost + " {% trans 'per hour' %}");
                     }
+                });
+            }
+
+            function initialize_consumption() {
+                $("#consumption-loader").show();
+            	$("#consumption-holder").hide();
+
+            	update_consumption();
+            }
+
+            function update_consumption()
+            {
+                $.ajax({
+                    url: "{% url 'frontend:dashboard-xhr-consumption' %}"
+                }).done(function(data) {
+                	$("#consumption-loader").hide();
+                    $("#consumption-holder").html(data).show();
                 });
             }
             

--- a/dsmr_frontend/templates/dsmr_frontend/dashboard.html
+++ b/dsmr_frontend/templates/dsmr_frontend/dashboard.html
@@ -148,7 +148,7 @@
 
     {% if capabilities.electricity or capabilities.electricity_returned or capabilities.gas %}
     <div class="row consumption-block">
-        <div class="col-md-12" id="consumption_holder">
+        <div class="col-md-12">
             <div id="consumption-loader" class="xhr-hidden text-center"><i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i></div>
             <div id="consumption-holder"></div>
         </div>

--- a/dsmr_frontend/templates/dsmr_frontend/fragments/dashboard-xhr-consumption.html
+++ b/dsmr_frontend/templates/dsmr_frontend/fragments/dashboard-xhr-consumption.html
@@ -1,0 +1,57 @@
+{% load humanize %}
+{% load i18n %} 
+{% load l10n %}
+
+<div class="panel">
+    <header class="panel-heading">
+        {{ consumption.day }}
+
+        <small class="pull-right">
+            <a href="{% url 'admin:dsmr_stats_note_add' %}?day={% now 'DJANGO_DATE_FORMAT' %}">
+                <span class="badge bg-green"><i class="fa fa-plus"></i> &nbsp; {% trans "Add note for today" %}</span>
+            </a>
+        </small>
+    </header>
+    <div class="panel-body">
+        <table class="table table-condensed">
+            <tr>
+                <th class="col-md-6"></th>
+                <th class="col-md-2">{% if capabilities.electricity %}{% trans "Consumed" %} ({% trans "kWh" noop %}{% if capabilities.gas %} / {% trans "m<sup>3</sup>" noop %}{% endif %}){% endif %}</th>
+                <th class="col-md-2">{% if capabilities.electricity_returned %}{% trans "Returned" %} ({% trans "kWh" noop %}){% endif %}</th>
+                <th class="col-md-2">{% trans "Cost" %} (&euro;)</th>
+            </tr>
+            {% if frontend_settings.merge_electricity_tariffs %}<tr>
+                <td>{% if capabilities.electricity %}{% trans "Electricity (single tariff)" %}{% endif %}</td>
+                <td><span class="badge bg-red" id="consumption_electrity_merged">{% if capabilities.electricity %}{{ consumption.electricity_merged|default:'-'|floatformat:2 }} </span>{% endif %}</td>
+                <td><span class="badge bg-green" id="consumption_electrity_returned_merged">{% if capabilities.electricity_returned %}{{ consumption.electricity_returned_merged|default:'-'|floatformat:2 }}{% endif %}</span></td>
+                <td><span class="badge bg-black">{% if capabilities.electricity %}{{ consumption.electricity_cost_merged|default:'-' }}{% endif %}</span></td>
+            </tr>
+            {% else %}<tr>
+                <td>{% if capabilities.electricity %}{% trans "Electricity 1 (low tariff)" %}{% endif %}</td>
+                <td><span class="badge bg-red">{% if capabilities.electricity %}{{ consumption.electricity1|default:'-'|floatformat:2 }} </span>{% endif %}</td>
+                <td><span class="badge bg-green">{% if capabilities.electricity_returned %}{{ consumption.electricity1_returned|default:'-'|floatformat:2 }}{% endif %}</span></td>
+                <td><span class="badge bg-black">{% if capabilities.electricity %}{{ consumption.electricity1_cost|default:'-' }}{% endif %}</span></td>
+            </tr><tr>
+                <td>{% if capabilities.electricity %}{% trans "Electricity 2 (high tariff)" %}{% endif %}</td>
+                <td><span class="badge bg-red">{% if capabilities.electricity %}{{ consumption.electricity2|default:'-'|floatformat:2 }}{% endif %}</span></td>
+                <td><span class="badge bg-green">{% if capabilities.electricity_returned %}{{ consumption.electricity2_returned|default:'-'|floatformat:2 }}{% endif %}</span></td>
+                <td><span class="badge bg-black">{% if capabilities.electricity %}{{ consumption.electricity2_cost|default:'-' }}{% endif %}</span></td>
+            </tr>
+            {% endif %}
+
+            {% if capabilities.gas %}<tr>
+                <td> {% trans "Gas" %}</td>
+                <td><span class="badge bg-orange">{{ consumption.gas|default:'-'|floatformat:2 }}</span></td>
+                <td>&nbsp;</td>
+                <td><span class="badge bg-black">{{ consumption.gas_cost|default:'-' }}</span></td>
+            </tr>
+            {% endif %}
+            <tr>
+                <td style="font-weight: bold;">{% trans "Total" %}</td>
+                <td><span class="badge bg-red">{% if capabilities.electricity %}{{ consumption.electricity_merged|default:'-'|floatformat:2 }}  </span>{% endif %}</td>
+                <td><span class="badge bg-green">{% if capabilities.electricity_returned %}{{ consumption.electricity_returned_merged|default:'-'|floatformat:2 }}{% endif %}</span></td>
+                <td><span class="badge bg-black">{{ consumption.total_cost|default:'-' }}</span></td>
+            </tr>
+        </table>
+    </div>
+</div>

--- a/dsmr_frontend/templates/dsmr_frontend/fragments/dashboard-xhr-consumption.html
+++ b/dsmr_frontend/templates/dsmr_frontend/fragments/dashboard-xhr-consumption.html
@@ -48,8 +48,8 @@
             {% endif %}
             <tr>
                 <td style="font-weight: bold;">{% trans "Total" %}</td>
-                <td><span class="badge bg-red">{% if capabilities.electricity %}{{ consumption.electricity_merged|default:'-'|floatformat:2 }}  </span>{% endif %}</td>
-                <td><span class="badge bg-green">{% if capabilities.electricity_returned %}{{ consumption.electricity_returned_merged|default:'-'|floatformat:2 }}{% endif %}</span></td>
+                <td><span class="badge bg-red">{% if capabilities.electricity and not frontend_settings.merge_electricity_tariffs %}{{ consumption.electricity_merged|default:'-'|floatformat:2 }}  </span>{% endif %}</td>
+                <td><span class="badge bg-green">{% if capabilities.electricity_returned and not frontend_settings.merge_electricity_tariffs%}{{ consumption.electricity_returned_merged|default:'-'|floatformat:2 }}{% endif %}</span></td>
                 <td><span class="badge bg-black">{{ consumption.total_cost|default:'-' }}</span></td>
             </tr>
         </table>

--- a/dsmr_frontend/tests/webinterface/test_dashboard.py
+++ b/dsmr_frontend/tests/webinterface/test_dashboard.py
@@ -50,9 +50,6 @@ class TestViews(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('track_temperature', response.context)
 
-        if self.support_data:
-            self.assertIn('consumption', response.context)
-
     @mock.patch('django.utils.timezone.now')
     def test_dashboard_xhr_header(self, now_mock):
         now_mock.return_value = timezone.make_aware(timezone.datetime(2015, 11, 15))
@@ -94,6 +91,16 @@ class TestViews(TestCase):
         )
         self.assertEqual(response.status_code, 200, response.content)
         self.assertEqual(response['Content-Type'], 'application/json')
+
+    def test_dashboard_xhr_consumption(self):
+        response = self.client.get(
+            reverse('{}:dashboard-xhr-consumption'.format(self.namespace))
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+
+        if self.support_data:
+            self.assertIn('consumption', response.context)
 
     @mock.patch('django.utils.timezone.now')
     def test_dashboard_xhr_graphs(self, now_mock):

--- a/dsmr_frontend/urls.py
+++ b/dsmr_frontend/urls.py
@@ -2,7 +2,7 @@ from django.views.decorators.cache import cache_page
 from django.conf import settings
 from django.conf.urls import url
 
-from dsmr_frontend.views.dashboard import Dashboard, DashboardXhrHeader, Dashboard, DashboardXhrConsumption, \
+from dsmr_frontend.views.dashboard import Dashboard, DashboardXhrHeader, DashboardXhrConsumption, \
     DashboardXhrGraphs, DashboardXhrNotificationRead
 from dsmr_frontend.views.archive import Archive, ArchiveXhrSummary, ArchiveXhrGraphs
 from dsmr_frontend.views.statistics import Statistics, StatisticsXhrData

--- a/dsmr_frontend/urls.py
+++ b/dsmr_frontend/urls.py
@@ -2,8 +2,8 @@ from django.views.decorators.cache import cache_page
 from django.conf import settings
 from django.conf.urls import url
 
-from dsmr_frontend.views.dashboard import Dashboard, DashboardXhrHeader, DashboardXhrGraphs, \
-    DashboardXhrNotificationRead
+from dsmr_frontend.views.dashboard import Dashboard, DashboardXhrHeader, Dashboard, DashboardXhrConsumption, \
+    DashboardXhrGraphs, DashboardXhrNotificationRead
 from dsmr_frontend.views.archive import Archive, ArchiveXhrSummary, ArchiveXhrGraphs
 from dsmr_frontend.views.statistics import Statistics, StatisticsXhrData
 from dsmr_frontend.views.trends import Trends
@@ -17,6 +17,7 @@ urlpatterns = [
     # Public views.
     url(r'^$', Dashboard.as_view(), name='dashboard'),
     url(r'^xhr/header$', DashboardXhrHeader.as_view(), name='dashboard-xhr-header'),
+    url(r'^xhr/consumption', DashboardXhrConsumption.as_view(), name='dashboard-xhr-consumption'),
     url(r'^xhr/graphs$', DashboardXhrGraphs.as_view(), name='dashboard-xhr-graphs'),
     url(r'^xhr/notification-read$', DashboardXhrNotificationRead.as_view(), name='dashboard-xhr-notification-read'),
     url(r'^archive$', Archive.as_view(), name='archive'),

--- a/dsmr_frontend/views/dashboard.py
+++ b/dsmr_frontend/views/dashboard.py
@@ -36,15 +36,6 @@ class Dashboard(TemplateView):
         context_data['track_temperature'] = weather_settings.track
         context_data['notifications'] = Notification.objects.unread()
 
-        try:
-            latest_electricity = ElectricityConsumption.objects.all().order_by('-read_at')[0]
-        except IndexError:
-            # Don't even bother when no data available.
-            return context_data
-
-        context_data['consumption'] = dsmr_consumption.services.day_consumption(
-            day=timezone.localtime(latest_electricity.read_at).date()
-        )
         today = timezone.localtime(timezone.now()).date()
         context_data['month_statistics'] = dsmr_stats.services.month_statistics(target_date=today)
         return context_data
@@ -97,6 +88,28 @@ class DashboardXhrHeader(View):
             )
 
         return HttpResponse(json.dumps(data), content_type='application/json')
+
+
+class DashboardXhrConsumption(TemplateView):
+    """ XHR view for fetching consumption, HTML response. """
+    template_name = 'dsmr_frontend/fragments/dashboard-xhr-consumption.html'
+
+    def get_context_data(self, **kwargs):
+        context_data = super(DashboardXhrConsumption, self).get_context_data(**kwargs)
+        context_data['capabilities'] = dsmr_backend.services.get_capabilities()
+        context_data['frontend_settings'] = FrontendSettings.get_solo()
+
+        try:
+            latest_electricity = ElectricityConsumption.objects.all().order_by('-read_at')[0]
+        except IndexError:
+            # Don't even bother when no data available.
+            return context_data
+
+        context_data['consumption'] = dsmr_consumption.services.day_consumption(
+            day=timezone.localtime(latest_electricity.read_at).date()
+        )
+
+        return context_data
 
 
 class DashboardXhrGraphs(View):


### PR DESCRIPTION
Dit verplaatst het verbruik panel naar een aparte template, die elke 20 seconden wordt ververst met een ajax call. Dit voorkomt dat bij het lang laten openstaan van het dashboard het verbruik achter loopt op het eigenlijke verbruik.

Ik heb voor 20 seconden gekozen omdat bij 2 kW het verbruik per 20 seconden ongeveer 0.01 kWh is, wat het minimale is wat je kunt zien. Heel veel meer precisie heb je niet nodig lijkt mij. Als dit een ander interval moet zijn dan hoor ik het graag.

Verder heb ik zoveel mogelijk geprobeerd de indeling aan te houden die ook in de rest van het project wordt gebruikt.