### PR TITLE
Verbeter melding voor te veel onverwerkte metingen

### DIFF
--- a/dsmr_frontend/templates/dsmr_frontend/status.html
+++ b/dsmr_frontend/templates/dsmr_frontend/status.html
@@ -100,7 +100,7 @@
                     <i class="fa fa-cogs"></i> &nbsp; {% trans "Telegram processing" %} <br />
                 </header>
                 <div class="panel-body">
-                    {% if unprocessed_readings > 30 %}
+                    {% if unprocessed_readings_overflow %}
                     <div class="alert alert-danger" role="alert">
                         <span class="fa fa-frown-o fa-2x"></span> 
                         {% blocktrans %}There are too many unprocessed telegrams.{% endblocktrans %}

--- a/dsmr_frontend/views/status.py
+++ b/dsmr_frontend/views/status.py
@@ -5,6 +5,7 @@ from django.http.response import HttpResponse
 from django.utils import timezone
 
 from dsmr_consumption.models.consumption import ElectricityConsumption, GasConsumption
+from dsmr_consumption.models.settings import ConsumptionSettings
 from dsmr_datalogger.models.reading import DsmrReading
 from dsmr_stats.models.statistics import DayStatistics
 import dsmr_backend.services
@@ -17,6 +18,22 @@ class Status(TemplateView):
         context_data = super(Status, self).get_context_data(**kwargs)
         context_data['capabilities'] = dsmr_backend.services.get_capabilities()
         context_data['unprocessed_readings'] = DsmrReading.objects.unprocessed().count()
+
+        consumption_settings = ConsumptionSettings.get_solo()
+        if consumption_settings.compactor_grouping_type == ConsumptionSettings.COMPACTOR_GROUPING_BY_READING:
+            # If data is grouped by reading then 30 unprocessed readings is too much
+            context_data['unprocessed_readings_overflow'] = context_data['unprocessed_readings'] > 30
+        # If the number of unprocessed readings is 0, getting the oldest reading will give trouble
+        elif context_data['unprocessed_readings'] == 0:
+            context_data['unprocessed_readings_overflow'] = False
+        else:
+            # Get oldest unprocessed reading
+            latest_unprocessed_reading = DsmrReading.objects.unprocessed().order_by('pk')[0]
+            delta_since_latest_unprocessed_reading = (
+                timezone.now() - latest_unprocessed_reading.timestamp
+            ).seconds
+            # If data is grouped by minute then not having processed a 2 minute old reading is too much
+            context_data['unprocessed_readings_overflow'] = delta_since_latest_unprocessed_reading > 120
 
         try:
             context_data['latest_reading'] = DsmrReading.objects.all().order_by('-pk')[0]


### PR DESCRIPTION
Deze verbetering werd genoemd in #387 . Deze update bepaalt afhankelijk van de instellingen voor het groeperen van metingen of het aantal onverwerkte telegrammen teveel is.
In het geval dat metingen niet worden gegroepeerd is meer dan 30 onverwerkte metingen te veel.
In het geval dat metingen worden gegroepeerd per minuut is het aantal teveel als de oudste onverwerkte meting meer dan 2 minuten oud is. Op deze manier werkt het voor DSMR 4 en 5.