### PR TITLE
iOS Web App: prevent same-window links from being opened externally

### DIFF
--- a/dsmr_frontend/static/dsmr_frontend/js/global.js
+++ b/dsmr_frontend/static/dsmr_frontend/js/global.js
@@ -1,0 +1,7 @@
+$('a').click(function(event) {
+    // When DSMR Reader is ran as a standalone iOS Web App, prevent links targetting the same window from being opened externally.
+    if (navigator.standalone === true && $(this).attr('target') !== '_blank') {
+        event.preventDefault();
+        location.href = $(this).attr('href');
+    }
+});

--- a/dsmr_frontend/templates/dsmr_frontend/base.html
+++ b/dsmr_frontend/templates/dsmr_frontend/base.html
@@ -168,15 +168,7 @@
         <script src="{% static 'dsmr_frontend/js/jquery-3.1.1.min.js' %}" type="text/javascript"></script>
         <script src="{% static 'dsmr_frontend/js/bootstrap.min.js' %}" type="text/javascript"></script>
         <script src="{% static 'dsmr_frontend/js/Director/app.js' %}?v=2" type="text/javascript"></script>
-        <script type="text/javascript">
-            $('a').click(function(event) {
-                // When DSMR Reader is ran as a standalone iOS Web App, prevent links targetting the same window from being opened externally.
-                if (navigator.standalone === true && $(this).attr('target') !== '_blank') {
-                    event.preventDefault();
-                    location.href = $(this).attr('href');
-                }
-            });
-        </script>
+        <script src="{% static 'dsmr_frontend/js/global.js' %}" type="text/javascript"></script>
         {% endblock %}
     </body>
 </html>

--- a/dsmr_frontend/templates/dsmr_frontend/base.html
+++ b/dsmr_frontend/templates/dsmr_frontend/base.html
@@ -164,12 +164,19 @@
             </aside><!-- /.right-side -->
         </div><!-- ./wrapper -->
 
-		{% block javascript %}
+        {% block javascript %}
         <script src="{% static 'dsmr_frontend/js/jquery-3.1.1.min.js' %}" type="text/javascript"></script>
-
         <script src="{% static 'dsmr_frontend/js/bootstrap.min.js' %}" type="text/javascript"></script>
         <script src="{% static 'dsmr_frontend/js/Director/app.js' %}?v=2" type="text/javascript"></script>
-        
+        <script type="text/javascript">
+            $('a').click(function(event) {
+                // When DSMR Reader is ran as a standalone iOS Web App, prevent links targetting the same window from being opened externally.
+                if (navigator.standalone === true && $(this).attr('target') !== '_blank') {
+                    event.preventDefault();
+                    location.href = $(this).attr('href');
+                }
+            });
+        </script>
         {% endblock %}
     </body>
 </html>


### PR DESCRIPTION
By default, iOS Web Apps open any link (`<a>` tag) in an external browser. This happens even when the `target` attribute isn't set to `_blank`.

This change prevents links targetting the same window from being opened externally. They are instead opened within the Web App itself.