### PR TITLE
PVOutput exports schedulen naar ingestelde upload interval

### DIFF
--- a/dsmr_pvoutput/services.py
+++ b/dsmr_pvoutput/services.py
@@ -27,13 +27,13 @@ def schedule_next_export():
     next_export = round_to_nearest_upload_interval(date=next_export, round_to_minutes=status_settings.upload_interval)
 
     print(' - PVOutput | Delaying the next export until: {}'.format(next_export))
-    
+
     status_settings.next_export = next_export
     status_settings.save()
 
 
 def round_to_nearest_upload_interval(date=None, round_to_minutes=5):
-    if (date == None):
+    if date is None:
         date = timezone.now()
 
     round_to_seconds = round_to_minutes*60


### PR DESCRIPTION
Deze PR lost een klein schoonheidsfoutje op in de PVOutput export. Af en toe laat de export namelijk een gat vallen aan de kant van PVO en dat ziet er dan zo uit:

![image](https://user-images.githubusercontent.com/1721382/36526940-50805bf4-17b0-11e8-8471-8ea94f1edfd6.png)

Na wat pluiswerk in de logs, kwam ik tot de conclusie dat de upload tijd uiteindelijk een beetje gaat verschuiven in seconden en niet exact altijd 5 minuten is als je dat ingesteld hebt. De timestamp van de upload wordt daarnaast afgerond op hele minuten, waardoor de hele tijd ineens met een minuut aangepast wordt. Dit veroorzaakt timings als:

1. PVOutput upload om 15:17
2. PVOutput upload om 15:22 (~5 minuten verschil)
3. PVOutput upload om 15:2**8** (~5 minuten verschil, maar naar boven afgerond)

Dit betekent dat de uploads aan de kant van PVO ook anders afgerond worden, namelijk naar respectievelijk: 15:15, 15:20 en 15:30. Je mist in dit scenario dus de 15:25 upload. Ik heb meerdere van deze situaties bekeken en vergeleken met de log en de oorzaak lijkt elke keer zo'n versprongen minuut te zijn.

In deze PR die ik inmiddels al een paar dagen lokaal gebruik, rond ik het schedule tijdstip af naar het ingestelde aantal minuten maar dan alvast aan de kant van DSMR. De timing kan nog altijd wel een paar seconden afwijken maar dit verschil wordt elke keer weg 'afgerond'. Dit is voldoende om het probleem op te lossen, denk ik. 

Ik ben geen Python eindbaas noch Django maar ik heb wel m'n best er op gedaan. Kon dit alleen testen door de code op mijn productie dsmr te draaien eigenlijk en heb alleen met mijn interval van 5 minuten getest (maar ik zie niet hoe dat een probleem kan zijn). Kijk er dus nog even goed naar zou ik zeggen 👍  Maar wellicht dat anderen dit verschijnsel ook af en toe bij PVO zien.