### PR TITLE
Retrieve the current energycontract for the statistics page

### DIFF
--- a/dsmr_consumption/services.py
+++ b/dsmr_consumption/services.py
@@ -389,8 +389,7 @@ def current_energy_contract():
     data = []
 
     for current in EnergySupplierPrice.objects.all().order_by('-start'):
-        if current.start < timezone.now().date() and current.end >timezone.now().date():
-
+        if current.start < timezone.now().date() and current.end > timezone.now().date():
             return {
                 'description': current.description,
                 'start': current.start,

--- a/dsmr_consumption/services.py
+++ b/dsmr_consumption/services.py
@@ -385,7 +385,6 @@ def clear_consumption():
 
 def current_energy_contract():
     """Return the current energe contract. """
-    data = []
 
     for current in EnergySupplierPrice.objects.all().order_by('-start'):
         if current.start < timezone.now().date() and current.end > timezone.now().date():

--- a/dsmr_consumption/services.py
+++ b/dsmr_consumption/services.py
@@ -385,7 +385,6 @@ def clear_consumption():
 
 def current_energy_contract():
     """Return the current energe contract. """
-    import dsmr_stats.services  # Prevents circular import.
     data = []
 
     for current in EnergySupplierPrice.objects.all().order_by('-start'):

--- a/dsmr_consumption/services.py
+++ b/dsmr_consumption/services.py
@@ -389,7 +389,6 @@ def current_energy_contract():
     data = []
 
     for current in EnergySupplierPrice.objects.all().order_by('-start'):
-        summary = dsmr_stats.services.range_statistics(start=current.start, end=current.end or timezone.now().date())
         if current.start < timezone.now().date() and current.end >timezone.now().date():
 
             return {

--- a/dsmr_consumption/services.py
+++ b/dsmr_consumption/services.py
@@ -383,6 +383,27 @@ def clear_consumption():
     GasConsumption.objects.all().delete()
 
 
+def current_energy_contract():
+    """Return the current energe contract. """
+    import dsmr_stats.services  # Prevents circular import.
+    data = []
+
+    for current in EnergySupplierPrice.objects.all().order_by('-start'):
+        summary = dsmr_stats.services.range_statistics(start=current.start, end=current.end or timezone.now().date())
+        if current.start < timezone.now().date() and current.end >timezone.now().date():
+
+            return {
+                'description': current.description,
+                'start': current.start,
+                'end': current.end,
+                'electricity_delivered_1_price': current.electricity_delivered_1_price,
+                'electricity_delivered_2_price': current.electricity_delivered_2_price,
+                'gas_price': current.gas_price,
+                'electricity_returned_1_price': current.electricity_returned_1_price,
+                'electricity_returned_2_price': current.electricity_returned_2_price,
+            }
+
+
 def summarize_energy_contracts():
     """ Returns a summery of all energy contracts and some statistics along them. """
     import dsmr_stats.services  # Prevents circular import.

--- a/dsmr_frontend/views/statistics.py
+++ b/dsmr_frontend/views/statistics.py
@@ -31,6 +31,7 @@ class Statistics(TemplateView):
 
         context_data['datalogger_settings'] = DataloggerSettings.get_solo()
         context_data['meter_statistics'] = MeterStatistics.get_solo()
+        context_data['energy_prices'] = dsmr_consumption.services.current_energy_contract()
 
         return context_data
 


### PR DESCRIPTION
On the statistics page I noticed the following message:
![selection_022](https://user-images.githubusercontent.com/104120/41934634-83d962fa-7987-11e8-8cad-5fb6e36ee131.png)

This is strange as I had just recently added additional contract data, like:
![selection_021](https://user-images.githubusercontent.com/104120/41934733-b4d839f8-7987-11e8-86a2-a3245786e63d.png)

It seems like the code for this was a forgotten todo .... now done.