### PR TITLE
Arrows on status page will now be hidden on small screens where they don't make sense anymore

### DIFF
--- a/dsmr_frontend/templates/dsmr_frontend/status.html
+++ b/dsmr_frontend/templates/dsmr_frontend/status.html
@@ -79,7 +79,7 @@
         </div>
     </div>
                  
-    <div class="row text-center">
+    <div class="row text-center hidden-xs hidden-sm">
         <div class="col-md-offset-5 col-md-2">
             <i class="fas fa-long-arrow-alt-down fa-3x" aria-hidden="true"></i>
         </div>
@@ -120,7 +120,7 @@
         </div>
     </div>
                  
-    <div class="row text-center">
+    <div class="row text-center hidden-xs hidden-sm">
         <div class="col-md-8">
             <i class="fas fa-long-arrow-alt-down fa-3x" aria-hidden="true"></i>
         </div>
@@ -205,7 +205,7 @@
         </div>
     </div>
     
-    <div class="row text-center">
+    <div class="row text-center hidden-xs hidden-sm">
         <div class="col-md-4">
             <i class="fas fa-long-arrow-alt-down fa-3x" aria-hidden="true"></i>
         </div>
@@ -300,7 +300,7 @@
         </div>
     </div>
                  
-    <div class="row text-center">
+    <div class="row text-center hidden-xs hidden-sm">
         <div class="col-md-4">
             <i class="fas fa-long-arrow-alt-down fa-3x" aria-hidden="true"></i>
         </div>


### PR DESCRIPTION
Weer een kleine aanpassing gemaakt. De pijlen op de status pagina verdwijnen nu op apparaten met een lage resolutie.

Met dank aan @Westie en @kestereverts om te zorgen dat deze PR degelijk is doordat ik nu gebruik maak van ingebouwde functionaliteit van het Bootstrap framework.