### PR TITLE
Fix voor negatieve gas consumption waarden #646

### DIFF
--- a/dsmr_consumption/services.py
+++ b/dsmr_consumption/services.py
@@ -158,7 +158,7 @@ def _compact_gas(dsmr_reading, grouping_type, **kwargs):
     # DSMR does not expose current gas rate, so we have to calculate it ourselves, relative to the previous gas
     # consumption, if any.
     try:
-        previous = GasConsumption.objects.all().order_by('-read_at')[0]
+        previous = GasConsumption.objects.filter(read_at__lt=read_at).order_by('-read_at')[0]
     except IndexError:
         gas_diff = 0
     else:


### PR DESCRIPTION
Zonder het filter vergelijkt hij een historische waarde die hij aan het verwerken is met de laatste waarde die al verwerkt is, en die is mogelijk/waarschijnlijk later dan de huidig verwerkte waarde, waardoor je dus negatieve gaswaarden krijgt.

Zoals genoemd ben ik niet dagelijks met Python bezig. Ik heb geprobeerd m'n Mac zover te krijgen dat ik ook tests goed uit kan voeren, maar daar kom ik nog net niet lekker uit. Hij blijft hangen bij het uitvoeren van `tools/quick-test.sh` vanwege het missen van wat packages denk ik. `gettext` bijvoorbeeld, dat is wel geinstalleerd via Homebrew, maar `msguniq` staat niet direct op het pad, dat soort grapjes.
Wel heb ik deze wijziging in een running docker image doorgevoerd, herstart, en opnieuw data ingeladen. Met die handmatige probeeractie wel gezien dat dit inderdaad lijkt te werken.