### PR TITLE
Add a timeout to the datalogger web request

### DIFF
--- a/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py
+++ b/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py
@@ -97,6 +97,7 @@ def send_telegram(telegram, api_url, api_key):
         api_url,
         headers={'X-AUTHKEY': api_key},
         data={'telegram': telegram},
+        timeout=5,
     )
 
     # Old versions of DSMR-reader return 200, new ones 201.

--- a/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py
+++ b/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py
@@ -97,7 +97,7 @@ def send_telegram(telegram, api_url, api_key):
         api_url,
         headers={'X-AUTHKEY': api_key},
         data={'telegram': telegram},
-        timeout=5,
+        timeout=60,
     )
 
     # Old versions of DSMR-reader return 200, new ones 201.


### PR DESCRIPTION
Bij recent onderhoud van de host waar dsmr op draait viel het me op dat de datalogger een restart nodig had.

Het toevoegen van deze timeout lijkt daarbij te helpen. De 5 seconden heb ik gekozen als de helft van de 10 seconden telegram interval.