### PR TITLE
make loglevel configurable by environmental variables

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -24,20 +24,17 @@ You can, however, have the application log more verbose by increasing the loggin
     
         Restart the commands in Supervisor to apply any changes.
     """
-    # LOGGING['loggers']['commands']['level'] = 'DEBUG'
+
+    LOGGING['loggers']['commands']['level'] = os.environ.get('DSMRREADER_LOGLEVEL')
 
 .. warning::
 
     **If you cannot find the code above**, you've probably installed DSMR-reader before v1.24.
-    You can add the following line to the end of the file::
+    You can update the following line to the end of the file::
 
-        LOGGING['loggers']['commands']['level'] = 'DEBUG'
+    LOGGING['loggers']['commands']['level'] = os.environ.get('DSMRREADER_LOGLEVEL')
 
-* Now remove the ``#`` from this line::
-
-    # LOGGING['loggers']['commands']['level'] = 'DEBUG'
-
-* To::
+* Simply replace with::
 
     LOGGING['loggers']['commands']['level'] = 'DEBUG'
 

--- a/dsmrreader/provisioning/django/mysql.py
+++ b/dsmrreader/provisioning/django/mysql.py
@@ -39,4 +39,6 @@ SECRET_KEY = os.environ.get('SECRET_KEY', DSMRREADER_SECRET_KEY)
 
     Restart the commands in Supervisor to apply any changes.
 """
-# LOGGING['loggers']['commands']['level'] = 'DEBUG'
+
+if os.environ.get('DSMRREADER_LOGLEVEL') is not None:
+    LOGGING['loggers']['commands']['level'] = os.environ.get('DSMRREADER_LOGLEVEL')

--- a/dsmrreader/provisioning/django/postgresql.py
+++ b/dsmrreader/provisioning/django/postgresql.py
@@ -39,4 +39,6 @@ SECRET_KEY = os.environ.get('SECRET_KEY', DSMRREADER_SECRET_KEY)
 
     Restart the commands in Supervisor to apply any changes.
 """
-# LOGGING['loggers']['commands']['level'] = 'DEBUG'
+
+if os.environ.get('DSMRREADER_LOGLEVEL') is not None:
+  LOGGING['loggers']['commands']['level'] = os.environ.get('DSMRREADER_LOGLEVEL')


### PR DESCRIPTION
This makes it possible to inject the loglevel by using the environmental variables. In the comments above it specified that the default was WARNING so I configured it like that.

This becomes very handy in using docker containers. Here we can just specify an environmental variable and restart the entire container and it will be picked up. 

Not sure why this is set always to DEBUG: https://github.com/dennissiemensma/dsmr-reader/blob/master/dsmrreader/provisioning/django/development.py#L16

### Check

- [x] Make sure you are making a pull request against the `development` branch. Also you should start your branch off the `development` branch.
