### PR TITLE
Configurable plugins by environmental variables

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
 ### Check
 
-- Make sure you are making a pull request against the `development` branch. Also you should start your branch off the `development` branch.
+- [ ] Make sure you are making a pull request against the `development` branch. Also you should start your branch off the `development` branch.

--- a/dsmrreader/provisioning/django/mysql.py
+++ b/dsmrreader/provisioning/django/mysql.py
@@ -33,6 +33,10 @@ SECRET_KEY = os.environ.get('SECRET_KEY', DSMRREADER_SECRET_KEY)
 if os.environ.get('DSMRREADER_LOGLEVEL') is not None:
     LOGGING['loggers']['commands']['level'] = os.environ.get('DSMRREADER_LOGLEVEL')
 
+if os.environ.get('DSMRREADER_PLUGINS') is not None:
+    DSMRREADER_PLUGINS = os.environ.get('DSMRREADER_PLUGINS').split(',')
+
+
 """
     Enable and change the logging level below to alter the verbosity of the (backend) command(s).
     - DEBUG:             Log everything.

--- a/dsmrreader/provisioning/django/postgresql.py
+++ b/dsmrreader/provisioning/django/postgresql.py
@@ -33,6 +33,9 @@ SECRET_KEY = os.environ.get('SECRET_KEY', DSMRREADER_SECRET_KEY)
 if os.environ.get('DSMRREADER_LOGLEVEL') is not None:
     LOGGING['loggers']['commands']['level'] = os.environ.get('DSMRREADER_LOGLEVEL')
 
+if os.environ.get('DSMRREADER_PLUGINS') is not None:
+    DSMRREADER_PLUGINS = os.environ.get('DSMRREADER_PLUGINS').split(',')
+
 """
     Enable and change the logging level below to alter the verbosity of the (backend) command(s).
     - DEBUG:             Log everything.


### PR DESCRIPTION
Hoi Dennis,

Hier de volgende optie om de `DSMRREADER_PLUGINS` via environmental variables in te laden.

## **NOTE**
De documentatie geeft aan dat de plugins in single quotes moeten staan. Dat zit hier dus niet in en weet niet of python dat goed vind.

Voorbeelden:
```
export DSMRREADER_PLUGINS="dsmr_plugins.modules.forward_telegram_to_api,dsmr_plugins.modules.forward_telegram_to_api2"
```

of via docker:
```
version: '3.6'

services:
 dsmr:
#    build: .
    image: xirixiz/dsmr-reader-docker:arm64v8-latest
    container_name: dsmr
    volumes:
      ...
      - ./modules/forward_telegram_to_api.py:/dsmr/dsmr_plugins/modules/forward_telegram_to_api.py
      - ./modules/forward_telegram_to_api2.py:/dsmr/dsmr_plugins/modules/forward_telegram_to_api2.py
    environment:
      ...
      - DSMRREADER_PLUGINS="dsmr_plugins.modules.forward_telegram_to_api,dsmr_plugins.modules.forward_telegram_to_api2"
    devices:
      - /dev/ttyUSB0:/dev/ttyUSB0
```

### Check

- [x] Make sure you are making a pull request against the `development` branch. Also you should start your branch off the `development` branch.
