### PR TITLE
Uurstatistieken missen de laatste minuut of seconde

### DIFF
--- a/dsmr_consumption/services.py
+++ b/dsmr_consumption/services.py
@@ -185,7 +185,7 @@ def _compact_gas(dsmr_reading, grouping_type, **kwargs):
 def consumption_by_range(start, end):
     """ Calculates the consumption of a range specified. """
     electricity_readings = ElectricityConsumption.objects.filter(
-        read_at__gte=start, read_at__lt=end,
+        read_at__gte=start, read_at__lte=end,
     ).order_by('read_at')
 
     gas_readings = GasConsumption.objects.filter(

--- a/dsmr_consumption/services.py
+++ b/dsmr_consumption/services.py
@@ -189,7 +189,7 @@ def consumption_by_range(start, end):
     ).order_by('read_at')
 
     gas_readings = GasConsumption.objects.filter(
-        read_at__gte=start, read_at__lt=end,
+        read_at__gte=start, read_at__lte=end,
     ).order_by('read_at')
 
     return electricity_readings, gas_readings
@@ -201,7 +201,10 @@ def day_consumption(day):
         'day': day
     }
     day_start = timezone.make_aware(timezone.datetime(year=day.year, month=day.month, day=day.day))
-    day_end = day_start + timezone.timedelta(days=1)
+    # Carefull: next day midnight is not always 24 hours away, need to use timedelta on date
+    # and then create timezone-aware datetime
+    next_day = day + timezone.timedelta(days=1)
+    day_end = timezone.make_aware(timezone.datetime(year=next_day.year, month=next_day.month, day=next_day.day))
     daily_energy_price = get_day_prices(day=day)
 
     electricity_readings, gas_readings = consumption_by_range(start=day_start, end=day_end)

--- a/dsmr_frontend/views/archive.py
+++ b/dsmr_frontend/views/archive.py
@@ -94,9 +94,12 @@ class ArchiveXhrGraphs(View):
 
         # Zoom to hourly data.
         if selected_level == 'days':
-            selected_date=selected_datetime.date()
-            next_date=selected_date + timezone.timedelta(days=1)
-            selected_day_end=timezone.make_aware(timezone.datetime(year=next_date.year,month=next_date.month,day=next_date.day))
+            selected_date = selected_datetime.date()
+            next_date = selected_date + timezone.timedelta(days=1)
+            selected_day_end = timezone.make_aware(timezone.datetime(
+                year=next_date.year,
+                month=next_date.month,
+                day=next_date.day))
             source_data = HourStatistics.objects.filter(
                 hour_start__gte=selected_datetime,
                 hour_start__lte=selected_day_end

--- a/dsmr_frontend/views/archive.py
+++ b/dsmr_frontend/views/archive.py
@@ -94,9 +94,12 @@ class ArchiveXhrGraphs(View):
 
         # Zoom to hourly data.
         if selected_level == 'days':
+            selected_date=selected_datetime.date()
+            next_date=selected_date + timezone.timedelta(days=1)
+            selected_day_end=timezone.make_aware(timezone.datetime(year=next_date.year,month=next_date.month,day=next_date.day))
             source_data = HourStatistics.objects.filter(
                 hour_start__gte=selected_datetime,
-                hour_start__lte=selected_datetime + timezone.timedelta(days=1)
+                hour_start__lte=selected_day_end
             ).order_by('hour_start')
             x_format = 'DSMR_GRAPH_SHORT_TIME_FORMAT'
             x_axis = 'hour_start'

--- a/dsmr_stats/services.py
+++ b/dsmr_stats/services.py
@@ -103,7 +103,10 @@ def create_statistics(target_day):
         # One day at a time to prevent backend blocking.
         create_daily_statistics(day=target_day)
 
-        for current_hour in range(0, 24 + 1):  # Current day + midnight of next day.
+        # We compute the hourly stats for every completed hour in the target day,
+        # i.e. the ones starting at 00:00, 01:00, ... , 23:00, covering the time
+        # till midnight of next day
+        for current_hour in range(0, 24):
             hour_start = start_of_day + timezone.timedelta(hours=current_hour)
             create_hourly_statistics(hour_start=hour_start)
 


### PR DESCRIPTION
Just after midnight, when we compute the daily and hourly stats for the
day that has just passed, we don't have yet the full data for the first hour
of the new day; therefore, we may only compute the hourly stats for
target day + 0 hour, target day + 1 hour, ..., target day + 23 hour, but
*not* for target day + 24 hour.

Otherwise, as we have only 1 or two telegrams, we would already create an entry
for target day + 24 hours (= target day + 1 day + 0 hour) with an incorrect
consumption of 0 (or nearly 0).

On the following day, we would again look at the hour starting at the next
target day, but as the entry already existed, we would not recompute it.

This is the easiest fix for the problem. Alternatively, one could also
- wait for 1 am before computing stats
- change the code to update an already existing hourly cosumption

### Check

- [x] Make sure you are making a pull request against the `development` branch. Also you should start your branch off the `development` branch.
