### PR TITLE
Correct background of inactive icons in Archive

### DIFF
--- a/dsmr_frontend/static/dsmr_frontend/css/style.css
+++ b/dsmr_frontend/static/dsmr_frontend/css/style.css
@@ -4212,3 +4212,6 @@ padding: 6px 10px;
 .st-blue {
   background-color: #23b7e5;
 }
+.st-gray {
+  background-color: #c0c0c0;
+}


### PR DESCRIPTION
The selected item is shown as a white icon against a green back-ground.
On selection of a new icon, the de-selected icon gets the class st-green
removed (which was adding the background color) and the (undefined) class
st-gray set.

As the class st-gray is not defined in the css file, we fall back to the
background defined in the base class, which at least on my PC cannot be
distinguished from the white color of the icon, which basically
becomes invisible (on my tablet, hower, this still remains visible as
some level of grey).

By defining a class st-gray with a background color of #c0c0c0, the
deselected icins become visible in all cases.

Tested on Edge, Chrome, Firefox, Silk (Fire HD), Samsung Internet

### Check

- [ ] Make sure you are making a pull request against the `development` branch. Also you should start your branch off the `development` branch.
